### PR TITLE
FIX: Docker container '_ARRAY_API not found'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.26.4
 tornado==6.3.3
 onnxruntime==1.15.1
 piper-phonemize==1.1.0


### PR DESCRIPTION
Ref to issue : [22187](https://github.com/spyder-ide/spyder/issues/22187)

Update: numpy==1.26.4 to fix this issue

![image](https://github.com/user-attachments/assets/303cdf14-2aa3-4997-b080-9d3d618dd12c)
